### PR TITLE
Warn user on `size_t` vs `int` insertion/querying.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ LINKER_OPT       = -L/usr/lib -lstdc++
 BUILD+=bloom_filter_example01
 BUILD+=bloom_filter_example02
 BUILD+=bloom_filter_example03
+BUILD+=bloom_filter_mwe
 
 all: $(BUILD)
 
@@ -30,6 +31,9 @@ bloom_filter_example02: bloom_filter.hpp bloom_filter_example02.cpp
 
 bloom_filter_example03: bloom_filter.hpp bloom_filter_example03.cpp
 	$(COMPILER) $(OPTIONS) bloom_filter_example03 bloom_filter_example03.cpp $(LINKER_OPT)
+
+bloom_filter_mwe: bloom_filter.hpp mwe.cpp
+	$(COMPILER) $(OPTIONS) bloom_filter_mwe mwe.cpp $(LINKER_OPT)
 
 clean:
 	rm -f core *.o *.bak *stackdump *#

--- a/mwe.cpp
+++ b/mwe.cpp
@@ -1,12 +1,11 @@
-/** The following code shows that when inserting `size_t` into the bloom filter
-* and checking for membership using `int`s, there are false-negatives.
+/** Below is a templatized reference implementation. Now, one has to specify
+* the type of the `bloom_filter`. Then, only those types can be inserted and queried
+* from the Bloom Filter.
 *
-* That in itself might be understandble because no implicit cast is possible.
-* There are, however, two things I would like to see changed:
-* 1. The example for false-positive checks from -1 to -100 is clearly misleading!
-*    For the example to be meaningful (int) 1 to 100 should be true-positives!
-* 2. Document this behaviour. The unsuspecting user should be aware that inserting
-*    size_t's and checking with int's doesn't work!
+* In the below example, we first create an bloom_filter<int> and then one of type
+* bloom_filter<std::string>. The <int>-type Bloom Filter can be queried for and
+* inserted into `size_t` values. There will be an implicit cast taking place but
+* it will show the "right" behavior!
 */
 #include <iostream>
 #include <string>
@@ -36,7 +35,15 @@ int main()
    parameters.compute_optimal_parameters();
 
    //Instantiate Bloom Filter
-   bloom_filter filter(parameters);
+   bloom_filter<int> filter(parameters);
+   filter.insert(-3);
+   // Below rightly doesn't compile.
+   //  filter.insert(std::string("Foo"));
+   //  filter.insert(3.2);
+   bloom_filter<std::string> string_filter(parameters);
+   string_filter.insert(std::string("foo"));
+   // Doesn't compile either.
+  //  string_filter.insert(12);
 
    // Insert into Bloom Filter
    {

--- a/mwe.cpp
+++ b/mwe.cpp
@@ -1,0 +1,87 @@
+/** The following code shows that when inserting `size_t` into the bloom filter
+* and checking for membership using `int`s, there are false-negatives.
+*
+* That in itself might be understandble because no implicit cast is possible.
+* There are, however, two things I would like to see changed:
+* 1. The example for false-positive checks from -1 to -100 is clearly misleading!
+*    For the example to be meaningful (int) 1 to 100 should be true-positives!
+* 2. Document this behaviour. The unsuspecting user should be aware that inserting
+*    size_t's and checking with int's doesn't work!
+*/
+#include <iostream>
+#include <string>
+
+#include "bloom_filter.hpp"
+
+int main()
+{
+
+   bloom_parameters parameters;
+
+   // How many elements roughly do we expect to insert?
+   parameters.projected_element_count = 1000;
+
+   // Maximum tolerable false positive probability? (0,1)
+   parameters.false_positive_probability = 0.0001; // 1 in 10000
+
+   // Simple randomizer (optional)
+   parameters.random_seed = 0xA5A5A5A5;
+
+   if (!parameters)
+   {
+      std::cout << "Error - Invalid set of bloom filter parameters!" << std::endl;
+      return 1;
+   }
+
+   parameters.compute_optimal_parameters();
+
+   //Instantiate Bloom Filter
+   bloom_filter filter(parameters);
+
+   // Insert into Bloom Filter
+   {
+      // Insert some numbers
+      for (std::size_t i = 0; i < 100; ++i)
+      {
+         filter.insert(i);
+      }
+   }
+
+   // Query Bloom Filter
+   {
+      // Query the existence of numbers
+      for (std::size_t i = 0; i < 100; ++i)
+      {
+         if (filter.contains(i))
+         {
+            std::cout << "BF contains: " << i << " : size_t" << std::endl;
+         }
+         else
+         {
+           std::cout << "False Negative: " << i << " : int" << std::endl;
+         }
+      }
+      for (int i = 0; i < 100; ++i)
+      {
+          if (filter.contains(i))
+          {
+              std::cout << "BF containts: " << i << " : int" << std::endl;
+          }
+          else
+          {
+              std::cout << "False Negative: " << i << " : int" << std::endl;
+          }
+      }
+
+      // Query the existence of invalid numbers
+      for (int i = -1; i > -100; --i)
+      {
+         if (filter.contains(i))
+         {
+            std::cout << "BF falsely contains: " << i << std::endl;
+         }
+      }
+   }
+
+   return 0;
+}

--- a/mwe.cpp
+++ b/mwe.cpp
@@ -58,7 +58,7 @@ int main()
          }
          else
          {
-           std::cout << "False Negative: " << i << " : int" << std::endl;
+           std::cout << "False Negative: " << i << " : size_t" << std::endl;
          }
       }
       for (int i = 0; i < 100; ++i)


### PR DESCRIPTION
_First, a very big Thank-You for writing this library in the first place! Easy to use and works!_ 

Today I've spent some very annoying minutes trying to figure out why none of my size_t's were inserted into the Bloom Filter.  It turned out that I was inserting size_t into the filter and checking for the same value but expressed as an int! 

To avoid others befalling the same problem I'd would suggest: (1) better documentation (see below), or (2) a fix.
## Attached Code

The following code shows that when inserting `size_t` into the bloom filter
and checking for membership using `int`s, there are false-negatives.

That in itself might be understandble because no implicit cast is possible.
There are, however, two things I would like to see changed:
1. The example for false-positive checks from -1 to -100 is clearly misleading!
   For the example to be meaningful (int) 1 to 100 should be true-positives!
2. Document this behaviour. The unsuspecting user should be aware that inserting
   size_t's and checking with int's doesn't work!
## Suggested Alternative

Why not _templatize_ `bloom_filter` itself? This would make this (user-) error impossible. Is there ever the case that a user wants to insert _different_ types of elements into the Bloom Filter?

Suggested usage:
`bloom_filter<myClass> filter(parameters)`
